### PR TITLE
Bug 62905: NextDesign.Cli.ExtensionFramework パッケージにおいて、パッケージ情報の"Repository"の"Url"に設定されているURLがプライベートリポジトリのURLであるため、ユーザは製品情報にアクセスできない。

### DIFF
--- a/src/NDExt/NDExt.csproj
+++ b/src/NDExt/NDExt.csproj
@@ -18,7 +18,7 @@
 
 * Utility commands for developing extensions for Next Design.
 * For Next Design V2.0 and later.</Description>
-    <PackageProjectUrl>https://docs.nextdesign.app/extension/docs/tools/ndext/intro</PackageProjectUrl>
+    <PackageProjectUrl>https://www.nextdesign.app</PackageProjectUrl>
     <NoDefaultExcludes>true</NoDefaultExcludes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReleaseNotes></PackageReleaseNotes>

--- a/src/NDExt/NDExt.csproj
+++ b/src/NDExt/NDExt.csproj
@@ -18,7 +18,7 @@
 
 * Utility commands for developing extensions for Next Design.
 * For Next Design V2.0 and later.</Description>
-    <PackageProjectUrl>https://www.nextdesign.app</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/denso-create/NextDesign-NDExt</PackageProjectUrl>
     <NoDefaultExcludes>true</NoDefaultExcludes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReleaseNotes></PackageReleaseNotes>


### PR DESCRIPTION
## 位置づけ
このプルリクエストは、https://github.com/miles-team/NextDesign/issues/6825 に対応します。

## CRレビュー観点
以下のCRレビュー観点について確認しました。

凡例：
- [x]：確認済み
- [-]：確認対象外

- [-] クラス名、メソッド名、フィールド名は適切か
  - 名前を見ただけで、何をするメソッドか、何を保持するフィールドかを判断できるか。
  - メソッド名が漠然としたものになってしまう場合、メソッドに複数の処理を詰め込みすぎていないかを確認する。
- [-] コメントはわかりやすく、正確に、十分に記述してあるか
  - 書いてあるコメントの情報だけで戸惑わずに利用できるか。メソッドの引数に値域は明記されているか？
  - 特殊なロジック、違和感を感じるような処理順序など、保守者が見て理解が難しいようなものは、そうしている理由を記述すること。既存の実装で不足しているものがあればコメント追記すること。
- [-] 変更範囲の単体テストのC0カバレッジは80%以上である。
- [-] ソリューション全体のUTを実行し、全件合格した。

## 変化点
PRにおける設計変化点の概要や注意点（複雑であったり、特別な設計にしているなど）を明らかにする。<br/>検証観点が妥当かCRレビューアが確認できるようにするため記載する。

- NDExt.csprojのPackageProjectUrlにNDExtのリポジトリのURLを設定

## 検証観点とデバッグ確認
### デバッグ項目
以下のデバッグ確認(効果確認、デグレード確認)を実施しました。

#### 効果確認
- バグタスクに記載

#### デグレード確認
- バグタスクに記載
